### PR TITLE
Fix: Show Popup on Reload and Display User Agent Without JavaScript

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,23 @@
-import { UserAgentProvider } from "../components/providers/userAgentProvider";
 import "./globals.css";
+import { Providers } from "@/components/providers";
+import { headers } from "next/headers";
 import { Layout } from "@/components/layout";
 
-const RootLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const headersList = headers();
+  const userAgent = headersList.get("user-agent") || "Unknown";
+
   return (
     <html lang="en">
       <body>
-        <UserAgentProvider>
-          <Layout>{children}</Layout>
-        </UserAgentProvider>
+        <Providers userAgent={userAgent}>
+         <Layout>{children}</Layout>
+          </Providers>
       </body>
     </html>
   );
-};
-
-export default RootLayout;
+}

--- a/src/views/products/products.tsx
+++ b/src/views/products/products.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Product } from "@/types";
 import { ProductModal } from "@/views/products/productModal/productModal";
 import { BackToHome } from "@/components/backToHome/backToHome";
@@ -20,12 +20,20 @@ export const Products: React.FC = () => {
 
   const handleOpenModal = useCallback((product: Product) => {
     setSelectedProduct(product);
+    localStorage.setItem("selectedProduct", JSON.stringify(product));
   }, []);
 
   const handleCloseModal = useCallback(() => {
     setSelectedProduct(null);
+    localStorage.removeItem("selectedProduct")
   }, []);
 
+    useEffect(() => {
+    const savedProduct = localStorage.getItem("selectedProduct");
+    if (savedProduct) {
+      setSelectedProduct(JSON.parse(savedProduct));
+    }
+  }, [])
   return (
     <div>
       <BackToHome />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/components/providers/try.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This pull request implements the following fixes:  

1. **Popup on Reload**:  
   - The popup logic is implemented using localStorage to track and manage its visibility state effectively.

2. **User-Agent Display Without JavaScript**:  
   - Implements server-side logic to fetch the `user-agent` from incoming request headers using Next.js's `headers()` API in the App Router.  